### PR TITLE
Stepper loc

### DIFF
--- a/src/arithmetic.c
+++ b/src/arithmetic.c
@@ -15,6 +15,9 @@ sexp* rray_add(sexp* x, sexp* y) {
   const r_ssize out_elements = rray_elements_from_dims(out_dims);
   const r_ssize out_dimensionality = r_length(out_dims);
 
+  x_dims = KEEP_N(rray_dims_expand(x_dims, out_dimensionality), n_protect);
+  y_dims = KEEP_N(rray_dims_expand(y_dims, out_dimensionality), n_protect);
+
   sexp* out = KEEP_N(r_new_int(out_elements), n_protect);
   int* p_out = r_int_deref(out);
 

--- a/src/broadcast.c
+++ b/src/broadcast.c
@@ -15,6 +15,8 @@ sexp* rray_broadcast(sexp* x, sexp* dims) {
   const r_ssize out_elements = rray_elements_from_dims(dims);
   const r_ssize out_dimensionality = r_length(dims);
 
+  x_dims = KEEP_N(rray_dims_expand(x_dims, out_dimensionality), n_protect);
+
   sexp* out = KEEP_N(r_new_int(out_elements), n_protect);
   int* p_out = r_int_deref(out);
 

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -1,7 +1,7 @@
 #include "rray.h"
 
 struct rray_stepper new_stepper(sexp* dims) {
-  r_ssize dimensionality = r_length(dims);
+  const r_ssize dimensionality = r_length(dims);
 
   sexp* array_loc = KEEP(r_new_int(dimensionality));
   int* p_array_loc = r_int_deref(array_loc);

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -19,8 +19,7 @@ struct rray_stepper new_stepper(sexp* dims) {
     .dims = dims,
     .p_dims = p_dims,
     .strides = strides,
-    .p_strides = p_strides,
-    .dimensionality = dimensionality
+    .p_strides = p_strides
   };
 
   FREE(2);

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -20,8 +20,7 @@ struct rray_stepper new_stepper(sexp* dims) {
     .p_dims = p_dims,
     .strides = strides,
     .p_strides = p_strides,
-    .dimensionality = dimensionality,
-    .synced = true
+    .dimensionality = dimensionality
   };
 
   FREE(2);

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -12,25 +12,18 @@ struct rray_stepper new_stepper(sexp* dims) {
 
   const int* p_dims = r_int_deref(dims);
 
-  sexp* broadcastable = KEEP(r_new_raw(dimensionality * sizeof(bool)));
-  bool* p_broadcastable = (bool*) r_raw_deref(broadcastable);
-
-  for (r_ssize i = 0; i < dimensionality; ++i) {
-    p_broadcastable[i] = (p_dims[i] == 1);
-  }
-
   struct rray_stepper stepper = {
     .loc = 0,
     .array_loc = array_loc,
     .p_array_loc = p_array_loc,
-    .broadcastable = broadcastable,
-    .p_broadcastable = p_broadcastable,
+    .dims = dims,
+    .p_dims = p_dims,
     .strides = strides,
     .p_strides = p_strides,
     .dimensionality = dimensionality,
     .synced = true
   };
 
-  FREE(3);
+  FREE(2);
   return stepper;
 }

--- a/src/stepper.h
+++ b/src/stepper.h
@@ -6,8 +6,8 @@
 
 /*
  * @param loc The flat location that matches the array location
- *   currently in `array_loc`. If `outdated` is `true`, this `loc` needs
- *   to be updated with a call to `stepper_sync()`.
+ *   currently in `array_loc`. This is updated alongside `array_loc`
+ *   through `stepper_step()` and `stepper_reset()`.
  *
  * @param array_loc The current array location. This is updated through
  *   `p_array_loc` when `stepper_step()` or `stepper_reset()` is called.
@@ -21,10 +21,6 @@
  * @param p_strides A pointer to `strides`.
  *
  * @param dimensionality The number of original dimensions.
- *
- * @param synced A signal for whether `stepper_loc()` needs to update the
- *   stored location or not. If we are broadcasting an axis, no updating needs
- *   to happen because we are repeatedly accessing the same value.
  */
 struct rray_stepper {
   r_ssize loc;
@@ -39,7 +35,6 @@ struct rray_stepper {
   const r_ssize* p_strides;
 
   const r_ssize dimensionality;
-  bool synced;
 };
 
 
@@ -55,21 +50,23 @@ struct rray_stepper new_stepper(sexp* dims);
 
 // -----------------------------------------------------------------------------
 
-static inline void stepper_step(struct rray_stepper* p_stepper, r_ssize axis, r_ssize n) {
+static inline void stepper_step(struct rray_stepper* p_stepper, r_ssize axis) {
   const r_ssize dimensionality = p_stepper->dimensionality;
 
   if (axis >= dimensionality) {
     return;
   }
 
-  const int* p_dims = p_stepper->p_dims;
+  const int dim = p_stepper->p_dims[axis];
 
-  if (p_dims[axis] == 1) {
+  if (dim == 1) {
     return;
   }
 
-  p_stepper->p_array_loc[axis] += n;
-  p_stepper->synced = false;
+  const r_ssize stride = p_stepper->p_strides[axis];
+
+  ++p_stepper->p_array_loc[axis];
+  p_stepper->loc += stride;
 }
 
 static inline void stepper_reset(struct rray_stepper* p_stepper, r_ssize axis) {
@@ -79,32 +76,16 @@ static inline void stepper_reset(struct rray_stepper* p_stepper, r_ssize axis) {
     return;
   }
 
-  const int* p_dims = p_stepper->p_dims;
+  const int dim = p_stepper->p_dims[axis];
 
-  if (p_dims[axis] == 1) {
+  if (dim == 1) {
     return;
   }
+
+  const r_ssize stride = p_stepper->p_strides[axis];
 
   p_stepper->p_array_loc[axis] = 0;
-  p_stepper->synced = false;
-}
-
-static inline void stepper_sync(struct rray_stepper* p_stepper) {
-  if (p_stepper->synced) {
-    return;
-  }
-
-  const r_ssize dimensionality = p_stepper->dimensionality;
-  const int* p_array_loc = p_stepper->p_array_loc;
-  const r_ssize* p_strides = p_stepper->p_strides;
-
-  p_stepper->loc = rray_array_loc_as_flat_loc(
-    p_array_loc,
-    p_strides,
-    dimensionality
-  );
-
-  p_stepper->synced = true;
+  p_stepper->loc -= dim * stride;
 }
 
 // -----------------------------------------------------------------------------
@@ -132,7 +113,6 @@ static inline void stepper_sync(struct rray_stepper* p_stepper) {
 
 
 #define STEPPER_UNARY_SYNC(X_LOC) do { \
-  stepper_sync(p_x_stepper);           \
   X_LOC = x_stepper.loc;               \
 } while (0)
 
@@ -140,7 +120,7 @@ static inline void stepper_sync(struct rray_stepper* p_stepper) {
 #define STEPPER_UNARY_NEXT(OUT_DIMENSIONALITY, P_OUT_DIMS) do { \
   for (r_ssize axis = 0; axis < OUT_DIMENSIONALITY; ++axis) {   \
     ++p_out_array_loc[axis];                                    \
-    stepper_step(p_x_stepper, axis, 1);                         \
+    stepper_step(p_x_stepper, axis);                            \
                                                                 \
     /* Continue along axis */                                   \
     if (p_out_array_loc[axis] < P_OUT_DIMS[axis]) {             \
@@ -169,10 +149,7 @@ static inline void stepper_sync(struct rray_stepper* p_stepper) {
 
 
 #define STEPPER_BINARY_SYNC(X_LOC, Y_LOC) do { \
-  stepper_sync(p_x_stepper);                   \
   X_LOC = x_stepper.loc;                       \
-                                               \
-  stepper_sync(p_y_stepper);                   \
   Y_LOC = y_stepper.loc;                       \
 } while (0)
 
@@ -180,8 +157,8 @@ static inline void stepper_sync(struct rray_stepper* p_stepper) {
 #define STEPPER_BINARY_NEXT(OUT_DIMENSIONALITY, P_OUT_DIMS) do { \
   for (r_ssize axis = 0; axis < OUT_DIMENSIONALITY; ++axis) {    \
     ++p_out_array_loc[axis];                                     \
-    stepper_step(p_x_stepper, axis, 1);                          \
-    stepper_step(p_y_stepper, axis, 1);                          \
+    stepper_step(p_x_stepper, axis);                             \
+    stepper_step(p_y_stepper, axis);                             \
                                                                  \
     /* Continue along axis */                                    \
     if (p_out_array_loc[axis] < P_OUT_DIMS[axis]) {              \

--- a/src/stepper.h
+++ b/src/stepper.h
@@ -13,10 +13,8 @@
  *   `p_array_loc` when `stepper_step()` or `stepper_reset()` is called.
  * @param p_array_loc The pointer to `array_loc`.
  *
- * @param broadcastable A raw vector storing an array of booleans. These return
- *   true of `dim[axis]` is 1, and false otherwise.
- * @param p_broadcastable A bool pointer to the underlying data stored in
- *   `broadcastable`.
+ * @param dims The original dimensions.
+ * @param p_dims A pointer to `dims`.
  *
  * @param strides The strides for the original dimensions. These are stored as
  *   a raw vector backed by a r_ssize array.
@@ -34,8 +32,8 @@ struct rray_stepper {
   sexp* array_loc;
   int* p_array_loc;
 
-  sexp* broadcastable;
-  const bool* p_broadcastable;
+  sexp* dims;
+  const int* p_dims;
 
   sexp* strides;
   const r_ssize* p_strides;
@@ -47,7 +45,7 @@ struct rray_stepper {
 
 #define KEEP_RRAY_STEPPER(stepper, n) do { \
   KEEP((stepper)->array_loc);              \
-  KEEP((stepper)->broadcastable);          \
+  KEEP((stepper)->dims);                   \
   KEEP((stepper)->strides);                \
   n += 3;                                  \
 } while (0)
@@ -64,9 +62,9 @@ static inline void stepper_step(struct rray_stepper* p_stepper, r_ssize axis, r_
     return;
   }
 
-  const bool* p_broadcastable = p_stepper->p_broadcastable;
+  const int* p_dims = p_stepper->p_dims;
 
-  if (p_broadcastable[axis]) {
+  if (p_dims[axis] == 1) {
     return;
   }
 
@@ -81,9 +79,9 @@ static inline void stepper_reset(struct rray_stepper* p_stepper, r_ssize axis) {
     return;
   }
 
-  const bool* p_broadcastable = p_stepper->p_broadcastable;
+  const int* p_dims = p_stepper->p_dims;
 
-  if (p_broadcastable[axis]) {
+  if (p_dims[axis] == 1) {
     return;
   }
 

--- a/tests/testthat/test-broadcast.R
+++ b/tests/testthat/test-broadcast.R
@@ -1,0 +1,6 @@
+test_that("broadcasting works with implicit dimensionality expansion", {
+  expect_identical(
+    rray_broadcast(1L, c(1, 2)),
+    matrix(1L, nrow = 1, ncol = 2)
+  )
+})


### PR DESCRIPTION
Simplifications to `stepper_` helpers by keeping track of `loc` along the way, and removing the need for `dimensionality` by expanding implicit dimensions

Really good speed improvements from this